### PR TITLE
fix: rework backup on save

### DIFF
--- a/package-lock.json
+++ b/package-lock.json
@@ -10,7 +10,6 @@
         "@mantine/dates": "^8.1.3",
         "@mantine/form": "^8.1.3",
         "@mantine/hooks": "^8.1.3",
-        "@mantine/modals": "^8.1.3",
         "@mantine/notifications": "^8.1.3",
         "@tabler/icons-react": "^3.34.0",
         "@tanstack/react-table": "^8.21.0",
@@ -1145,18 +1144,6 @@
       "license": "MIT",
       "peerDependencies": {
         "react": "^18.x || ^19.x"
-      }
-    },
-    "node_modules/@mantine/modals": {
-      "version": "8.1.3",
-      "resolved": "https://registry.npmjs.org/@mantine/modals/-/modals-8.1.3.tgz",
-      "integrity": "sha512-PTLquO7OuYHrbezhjqf1fNwxU1NKZJmNYDOll6RHp6FPQ80xCVWQqVFsj3R8XsLluu2b5ygTYi+avWrUr1GvGg==",
-      "license": "MIT",
-      "peerDependencies": {
-        "@mantine/core": "8.1.3",
-        "@mantine/hooks": "8.1.3",
-        "react": "^18.x || ^19.x",
-        "react-dom": "^18.x || ^19.x"
       }
     },
     "node_modules/@mantine/notifications": {

--- a/package.json
+++ b/package.json
@@ -18,7 +18,6 @@
     "@mantine/dates": "^8.1.3",
     "@mantine/form": "^8.1.3",
     "@mantine/hooks": "^8.1.3",
-    "@mantine/modals": "^8.1.3",
     "@mantine/notifications": "^8.1.3",
     "@tabler/icons-react": "^3.34.0",
     "@tanstack/react-table": "^8.21.0",

--- a/playwright-tests/e2e/settings/settings.spec.ts
+++ b/playwright-tests/e2e/settings/settings.spec.ts
@@ -64,23 +64,23 @@ async function checkTaskAndTodosDoNotExist(page: Page) {
 async function enableBackupConfirmation(page: Page) {
     await navigateTo(page, links.settings);
 
-    const switchLabel = page.locator('text=Ask to backup before closing');
+    const switchLabel = page.locator('text=Warn before exiting');
     await expect(switchLabel).toBeVisible();
 
     await switchLabel.click();
 
-    await expect(page.getByText('Backup confirmation on close enabled')).toBeVisible();
+    await expect(page.getByText('Exit warning enabled')).toBeVisible();
 }
 
 async function disableBackupConfirmation(page: Page) {
     await navigateTo(page, links.settings);
 
-    const switchLabel = page.locator('text=Ask to backup before closing');
+    const switchLabel = page.locator('text=Warn before exiting');
     await expect(switchLabel).toBeVisible();
 
     await switchLabel.click();
 
-    await expect(page.getByText('Backup confirmation on close disabled')).toBeVisible();
+    await expect(page.getByText('Exit warning disabled')).toBeVisible();
 }
 
 async function isBackupConfirmationEnabled(page: Page): Promise<boolean> {
@@ -167,7 +167,7 @@ test('Restore from file restores tasks and todos', async ({ page }) => {
     await checkTaskAndTodosExist(page);
 });
 
-test('Backup confirmation can toggled', async ({ page }) => {
+test('Exit warning can be toggled', async ({ page }) => {
     await setup(page);
 
     await enableBackupConfirmation(page);
@@ -178,9 +178,7 @@ test('Backup confirmation can toggled', async ({ page }) => {
     expect(isEnabled).toBe(false);
 });
 
-test('Backup confirmation modal appears when closing tab with setting enabled', async ({
-    page,
-}) => {
+test('Browser warning appears when closing tab with setting enabled', async ({ page }) => {
     await setup(page);
 
     await enableBackupConfirmation(page);

--- a/playwright-tests/selectors/settings.selectors.ts
+++ b/playwright-tests/selectors/settings.selectors.ts
@@ -2,5 +2,5 @@ export const main = {
     backup: 'Backup',
     deleteAllData: 'Delete all data',
     restoreFromFile: 'Restore from file',
-    askToBackupBeforeClosing: 'Ask to backup before closing',
+    askToBackupBeforeClosing: 'Warn before exiting',
 };

--- a/src/i18n/locales/en.json
+++ b/src/i18n/locales/en.json
@@ -48,8 +48,8 @@
         "title": "Backup",
         "description": "Before clearing your browser cache, be sure to back up your data to prevent loss. Backing up protects against accidental deletion, system crashes, and software issues, ensuring you can easily restore your settings and preferences.",
         "button": "Backup",
-        "askBeforeClosing": "Ask to backup before closing",
-        "askBeforeClosingDescription": "When enabled, you'll be prompted to create a backup before closing the application. This gives you control over when backups are created."
+        "askBeforeClosing": "Warn before exiting",
+        "askBeforeClosingDescription": "When enabled, you'll get a browser warning before accidentally exiting the application. This reminds you to backup your data manually if needed."
       },
       "restore": {
         "title": "Restore from file",
@@ -124,8 +124,8 @@
     "reset": "Reset"
   },
   "notifications": {
-    "backupEnabled": "Backup confirmation on close enabled",
-    "backupDisabled": "Backup confirmation on close disabled",
+    "backupEnabled": "Exit warning enabled",
+    "backupDisabled": "Exit warning disabled",
     "dataRestored": "Data restored from file!",
     "dataDeleted": "Data deleted!",
     "importError": "Unable to import data!"

--- a/src/main.tsx
+++ b/src/main.tsx
@@ -6,7 +6,6 @@ import '@mantine/core/styles.css';
 import '@mantine/dates/styles.css';
 import '@mantine/notifications/styles.css';
 import { MantineProvider } from '@mantine/core';
-import { ModalsProvider } from '@mantine/modals';
 import { mantineTheme } from './theme.ts';
 import { Notifications } from '@mantine/notifications';
 import { HashRouter } from 'react-router';
@@ -16,10 +15,8 @@ createRoot(document.getElementById('root')!).render(
     <StrictMode>
         <HashRouter>
             <MantineProvider defaultColorScheme={'dark'} theme={mantineTheme}>
-                <ModalsProvider>
-                    <Notifications />
-                    <App />
-                </ModalsProvider>
+                <Notifications />
+                <App />
             </MantineProvider>
         </HashRouter>
     </StrictMode>,

--- a/src/services/backup/useBackupConfirmation.tsx
+++ b/src/services/backup/useBackupConfirmation.tsx
@@ -1,53 +1,18 @@
 import { useCallback, useEffect, useRef } from 'react';
 import { useLiveQuery } from 'dexie-react-hooks';
-import { modals } from '@mantine/modals';
-import { Text } from '@mantine/core';
 import { db } from '../../database/database.ts';
-import { download } from '../../download/download.ts';
 
 export const useBackupConfirmation = () => {
     const backupOnCloseSetting = useLiveQuery(() => db.settings.get('backupOnClose'));
     const beforeUnloadHandlerRef = useRef<((event: BeforeUnloadEvent) => void) | null>(null);
 
-    const backup = useCallback(async () => {
-        const settings = await db.settings.toArray();
-        const tasks = await db.tasks.toArray();
-        const todos = await db.todos.toArray();
-        download(`squirrel-backup_${new Date().toISOString()}.json`, { settings, tasks, todos });
-    }, []);
-
     const handleBeforeUnload = useCallback(
         (event: BeforeUnloadEvent) => {
             if (backupOnCloseSetting?.value === true) {
                 event.preventDefault();
-                event.returnValue = '';
-
-                modals.openConfirmModal({
-                    title: 'Backup before closing?',
-                    children: (
-                        <Text size="sm">
-                            Would you like to create a backup before closing the application? This
-                            will download your data to keep it safe.
-                        </Text>
-                    ),
-                    labels: { confirm: 'Yes, backup', cancel: 'No, just close' },
-                    onConfirm: () => {
-                        backup();
-                        // Allow the window to close after backup
-                        setTimeout(() => {
-                            window.close();
-                        }, 100);
-                    },
-                    onCancel: () => {
-                        // Allow the window to close without backup
-                        setTimeout(() => {
-                            window.close();
-                        }, 100);
-                    },
-                });
             }
         },
-        [backupOnCloseSetting?.value, backup],
+        [backupOnCloseSetting?.value],
     );
 
     useEffect(() => {


### PR DESCRIPTION
Summary
This Pull Request simplifies the project by removing the dependency on @mantine/modals, adjusting related code, and introducing a UX-related change where the "backup before closing" functionality is replaced with "warn before exiting."

Main Changes:
- Removed @mantine/modals from package.json, package-lock.json, and its associated usage in the codebase.
- Updated UX wording throughout the project: "backup before closing" is now "warn before exiting."
- Simplified backup handling by removing modal-based prompts in useBackupConfirmation.
- Adjustments to related test files to align with the new "warn before exiting" functionality and terminology.
- Small updates to localization strings and notification messages for consistency (i.e., backup confirmation replaced by exit warning).